### PR TITLE
Add single-quote rule to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,5 @@ indent_size = 2
 [*.md]
 trim_trailing_whitespace = false
 
+[*.js]
+quote_type = single


### PR DESCRIPTION
Defaults editor to prefer single-quotes over double-quotes in Javascript files.