### PR TITLE
Keyword matching

### DIFF
--- a/public/scripts/api-helpers.js
+++ b/public/scripts/api-helpers.js
@@ -94,7 +94,8 @@ const determineCategory = task => {
  * @return  {{}}      The original task + the data received from the API call
  */
 const callAPIByCategory = async (task) => {
-  const query = filterKeywords(task.description);
+  const query = removeFirstWord(task.description);
+  console.log("query", query);
   const encodedQuery = encodeURIComponent(query);
 
   switch (task.category) {
@@ -137,15 +138,6 @@ const timeoutPromise = (ms, promise) => {
   ]);
 };
 
-/**
- * Checks if given word is found in the given string
- * @param  {string}  str  String to check condition
- * @param  {string}  word Word to look for in the string
- * @return {boolean}      Boolean if word found in string
- */
-const findWordInString = (str, word) => {
-  return new RegExp('\\b' + word + '\\b', 'i').test(str);
-};
 
 /**
  * Matches string against key values to check for easy API match
@@ -157,36 +149,25 @@ const matchCategoryKeyword = (string) => {
   const categories = ['restaurants', 'films', 'books', 'products'];
   const keywords = ['eat', 'watch', 'read', 'buy'];
 
-  keywords.some((val, index) => {
-    if (findWordInString(string, val)) {
-      category = categories[index];
+  for (let i in keywords) {
+    if (string.trim().split(" ")[0].toLowerCase() === keywords[i]) {
+      category = categories[i];
     }
-  });
-
+  }
+  console.log("Keyword matched. Category:", category);
   return category;
 };
 
 /**
  * Trim given string of matched keyword and whitespace from the start/end
  * @param  {string} string Takes in string to check for keyword
- * @return {string}        Trimmed string
+ * @return {string}        Altered string
  */
-const filterKeywords = (string) => {
-  const keywords = ['eat', 'watch', 'read', 'buy'];
-  let newString = '';
-
-  keywords.some((val, index) => {
-    if (findWordInString(string, val)) {
-          const regEx = new RegExp(val, "ig");
-          if (newString) {
-            newString = newString.replace(regEx, '').trim();
-          } else {
-            newString = string.replace(regEx, '').trim();
-          }
-    }
-  });
-
-  return newString;
+const removeFirstWord = (string) => {
+  const splitTask = string.trim().split(" ");
+  splitTask.shift();
+  const filteredString = splitTask.join(" ");
+  return filteredString;
 };
 
 

--- a/public/scripts/api-helpers.js
+++ b/public/scripts/api-helpers.js
@@ -94,7 +94,7 @@ const determineCategory = task => {
  * @return  {{}}      The original task + the data received from the API call
  */
 const callAPIByCategory = async (task) => {
-  const query = removeFirstWord(task.description);
+  const query = filterKeyword(task.description);
   console.log("query", query);
   const encodedQuery = encodeURIComponent(query);
 
@@ -181,6 +181,7 @@ const matchCategoryKeyword = (string) => {
       category = categories[i];
     }
   }
+
   console.log("Keyword matched. Category:", category);
   return category;
 };
@@ -190,9 +191,13 @@ const matchCategoryKeyword = (string) => {
  * @param  {string} string Takes in string to check for keyword
  * @return {string}        Altered string
  */
-const removeFirstWord = (string) => {
+const filterKeyword = (string) => {
+  const keywords = ['eat', 'watch', 'read', 'buy'];
   const splitTask = string.trim().split(" ");
-  splitTask.shift();
+  const firstWord = splitTask[0].toLowerCase();
+  if (keywords.includes(firstWord)) {
+    splitTask.shift();
+  }
   const filteredString = splitTask.join(" ");
   return filteredString;
 };

--- a/public/scripts/client-helpers.js
+++ b/public/scripts/client-helpers.js
@@ -322,7 +322,7 @@ const renderDetails = function (category) {
             }
             let type = task.type.charAt(0).toUpperCase() + task.type.slice(1);
             taskElement.find(".genres").prepend(`
-                <span class="genre">${type}</span>
+                <span class="genre" id="shovie-type">${type}</span>
                 `);
 
             const ratings = task.ratings;
@@ -520,6 +520,9 @@ const getJustWatchURL = (film) => {
   const filmTitle = film.title.replace(regex, '');
   const titleArr = filmTitle.split(' ');
   const urlTitle = titleArr.join('-');
-
-  return `https://www.justwatch.com/ca/movie/${urlTitle}`;
+  let type = $("#shovie-type").text().toLowerCase();
+  if (type === "series") {
+    type = "tv-show";
+  }
+  return `https://www.justwatch.com/ca/${type}/${urlTitle}`;
 };

--- a/public/scripts/client-helpers.js
+++ b/public/scripts/client-helpers.js
@@ -54,7 +54,8 @@ const submitNewTask = async (element) => {
   if (!task.category || task.category === 'auto') {
     task = await determineCategory(task);
   } else {
-    await callAPIByCategory(task);
+    console.log("Selected category:", task.category);
+    task = await callAPIByCategory(task);
   }
 
   $.post('/tasks', task)


### PR DESCRIPTION
Rewrite the keyword matching algorithm: now it only evaluates the first word because:
  1. our keyword are usually the first word;
  2. if the keyword is indeed in the middle of the description, it could be part of the query; even if it's not, we must filter it out but it will force us to concatenate other parts of the description, altering the query. 
  3. We can't locate the query string if there are any other components. for example, "Let's watch a movie called Arrival", the best we can do is filter out "watch" and maybe "movie" and then the query would be "let's a called Arrival". it will take a very complex algorithm with great data support to locate the real query string "Arrival". We can only assume the description is "keyword + query", and considering our keywords are verbs, it's almost always the first word. It's much more possible that a keyword found in the middle of a task string is part of the query than that it's purposely put there. Who would type in "game of Watch thrones" or "Avatar: the way of water Watch"? 
  4. We can consider change description to task title and add a text field for entering additional comments, descriptions, details.