### PR TITLE
Fix hanging from amznResult condition

### DIFF
--- a/public/scripts/api-helpers.js
+++ b/public/scripts/api-helpers.js
@@ -257,7 +257,7 @@ const determineCategory = (task) => {
       }
 
       // Return category products if Amazon Price is fulfilled
-      if (amznResult.status === 'fulfilled') {
+      if (amznResult?.status === 'fulfilled') {
         task.category = 'products';
         task.data = amznResult.value;
         return task;


### PR DESCRIPTION
Added optional chain to in the `determineCategory()` function. The app was still hanging with a `500` status because of the undefined object. 

The optional chain `?.` prevents it from checking for the object key if the object is undefined or null, so it can resolve the program properly.